### PR TITLE
Modernize plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/work
+/work/
+/target/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,14 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  // Test Java 8 until plugin upgrades to a Jenkins version that does not support Java 8
+  configurations: [
+    [platform: 'windows', jdk: '17', jenkins: '2.382'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'linux',   jdk: '8'],
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     </licenses>
 
 	<scm>
-	   <connection>scm:git:ssh://github.com/jenkinsci/JDK_Parameter_Choice.git</connection>
-           <developerConnection>scm:git:ssh://git@github.com/jenkinsci/JDK_Parameter_Choice.git</developerConnection>
+	   <connection>scm:git:https://github.com/jenkinsci/JDK_Parameter_Choice.git</connection>
+           <developerConnection>scm:git:git@github.com:jenkinsci/JDK_Parameter_Choice.git</developerConnection>
            <url>https://github.com/jenkinsci/JDK_Parameter_Choice</url>	
 	</scm>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509</version>
+		<version>4.51</version>
+		<relativePath />
 	</parent>
 
 	<artifactId>JDK_Parameter_Plugin</artifactId>
@@ -29,7 +30,7 @@
            <url>https://github.com/jenkinsci/JDK_Parameter_Choice</url>	
 	</scm>
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<jenkins.version>2.346.3</jenkins.version>
 	</properties>
 
     <developers>
@@ -44,75 +45,6 @@
 	   <email>fabio.neves@datalex.com</email>
 	</developer>
 	</developers>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>com.cloudbees</groupId>
-					<artifactId>maven-license-plugin</artifactId>
-					<version>1.7</version>
-				</plugin>
-				<plugin>
-					<groupId>org.kohsuke</groupId>
-					<artifactId>access-modifier-checker</artifactId>
-					<version>1.4</version>
-				</plugin>
-				<plugin>
-					<groupId>org.jvnet.localizer</groupId>
-					<artifactId>maven-localizer-plugin</artifactId>
-					<version>1.14</version>
-				</plugin>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-enforcer-plugin</artifactId>
-										<versionRange>[1.0,)</versionRange>
-										<goals>
-											<goal>display-info</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.codehaus.gmaven</groupId>
-										<artifactId>gmaven-plugin</artifactId>
-										<versionRange>[1.3,)</versionRange>
-										<goals>
-											<goal>generateTestStubs</goal>
-											<goal>testCompile</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<version>1.90</version>
-				<extensions>true</extensions>
-			</plugin>
-		</plugins>
-	</build>
 
 	<repositories>
 		<repository>

--- a/src/main/java/com/datalex/jdkparameter/JavaParameterDefinition.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterDefinition.java
@@ -144,7 +144,7 @@ public class JavaParameterDefinition extends SimpleParameterDefinition {
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
         StringParameterValue paramValue = req.bindJSON(StringParameterValue.class, jo);
-        return new JavaParameterValue(paramValue.getName(), getDescription(), (String)paramValue.value);
+        return new JavaParameterValue(paramValue.getName(), getDescription(), paramValue.getValue());
     }
 
     @Override

--- a/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
@@ -8,6 +8,7 @@ import hudson.tasks.BuildWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,6 +37,25 @@ public class JavaParameterValue extends StringParameterValue {
 
     public void setvalue(String value) {
         this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return Objects.equals(value, ((JavaParameterValue)obj).getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 37;
     }
 
     @Override
@@ -76,5 +96,3 @@ public class JavaParameterValue extends StringParameterValue {
     }
 
 }
-
-

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/config.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/config.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- this is the page fragment displayed to set up a job -->
-<!--<?jelly escape-by-default='true'?>-->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
 
     <f:entry title="${%Name}" field="name">

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${it.name}" description="${it.description}">
         <f:textbox name="value" value="${it.value}" readonly="true" />

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
     Lets you specify a set of JDKs that can be picked from as a build parameter.
 </div>


### PR DESCRIPTION
## Modernize the plugin

- Ignore maven target directory
- Escape jelly pages
- Use getValue instead of referencing the value field
- Implement equals() and hashCode()
- Require Jenkins 2.346.3 or newer

This plugin has an implied dependency on the WMI Windows Agents plugin due to the old base Jenkins version that it requires.  Require a newer Jenkins version in order to remove the implied dependency on WMI Windows Agents plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
