### PR TITLE
[JENKINS-70309] Restore selectedJDK parameter

### DIFF
--- a/src/main/java/com/datalex/jdkparameter/JavaParameterDefinition.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterDefinition.java
@@ -3,9 +3,7 @@ package com.datalex.jdkparameter;
 import hudson.Extension;
 import hudson.model.JDK;
 import hudson.model.ParameterDefinition;
-import hudson.model.StringParameterValue;
 import hudson.model.ParameterValue;
-import hudson.model.SimpleParameterDefinition;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -24,7 +22,7 @@ import java.util.logging.Logger;
  * Time: 10:53 AM
  * To change this template use File | Settings | File Templates.
  */
-public class JavaParameterDefinition extends SimpleParameterDefinition {
+public class JavaParameterDefinition extends ParameterDefinition {
 
     private static final Logger LOGGER = Logger.getLogger(JavaParameterValue.class.getName());
 
@@ -127,11 +125,6 @@ public class JavaParameterDefinition extends SimpleParameterDefinition {
         return defaultJDK;
     }
 
-    @Override
-    public ParameterValue getDefaultParameterValue() {
-          return new JavaParameterValue(getName(), getDescription(), getDefaultJDK());
-    }
-
 
     //gets the list of JDKs to put in "selectable JDKs" array in job config, includes the base JDKs from jenkins
     public List<String>  getSelectableJDKNames(){
@@ -143,15 +136,17 @@ public class JavaParameterDefinition extends SimpleParameterDefinition {
 
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
-        StringParameterValue paramValue = req.bindJSON(StringParameterValue.class, jo);
-        return new JavaParameterValue(paramValue.getName(), getDescription(), paramValue.getValue());
+        final String name = jo.getString("name");
+        final String selectedJDK = jo.getString("selectedJDK");
+        return  new JavaParameterValue(name, getDescription(), selectedJDK);
     }
 
     @Override
-    public ParameterValue createValue(String value) {
-        return new JavaParameterValue(getName(), getDescription(), value);
+    public ParameterValue createValue(StaplerRequest req) {
+        String name = (String)req.getAttribute("name");
+        String selectedJDK = (String)req.getAttribute("selectedJDK");
+        return new JavaParameterValue(name, getDescription(), selectedJDK);
     }
-
 
     @Extension
     public static class DescriptorImpl extends ParameterDescriptor {

--- a/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
@@ -3,7 +3,7 @@ package com.datalex.jdkparameter;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.JDK;
-import hudson.model.StringParameterValue;
+import hudson.model.ParameterValue;
 import hudson.tasks.BuildWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -19,24 +19,24 @@ import java.util.logging.Logger;
  * Time: 11:28 AM
  * To change this template use File | Settings | File Templates.
  */
-public class JavaParameterValue extends StringParameterValue {
+public class JavaParameterValue extends ParameterValue {
 
     private static final Logger LOGGER = Logger.getLogger(JavaParameterValue.class.getName());
 
-    private String value;
+    private String selectedJDK;
 
     @DataBoundConstructor
-    public JavaParameterValue(String name, String description, String value){
+    public JavaParameterValue(String name, String description, String selectedJDK){
         super(name, description);
-        this.value = value;
+        this.selectedJDK = selectedJDK;
     }
 
-    public String getvalue() {
-        return value;
+    public String getSelectedJDK() {
+        return selectedJDK;
     }
 
-    public void setvalue(String value) {
-        this.value = value;
+    public void setSelectedJDK(String selectedJDK) {
+        this.selectedJDK = selectedJDK;
     }
 
     @Override
@@ -72,14 +72,14 @@ public class JavaParameterValue extends StringParameterValue {
         selected = new JDK(JavaParameterDefinition.DEFAULT_JDK,null);
 
         for(JDK jdk : jenkins.model.Jenkins.getInstance().getJDKs()) {
-            if(jdk.getName().equalsIgnoreCase(value))  {
+            if(jdk.getName().equalsIgnoreCase(selectedJDK))  {
                 selected = jdk;
                 jdkIsAvailable = true;
                 break;
             }
         }
 
-        if (value.equals(JavaParameterDefinition.DEFAULT_JDK)){
+        if (selectedJDK.equals(JavaParameterDefinition.DEFAULT_JDK)){
             jdkIsAvailable = true;
         }
 

--- a/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
@@ -6,7 +6,6 @@ import hudson.model.ParameterValue;
 import hudson.tasks.BuildWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,25 +34,6 @@ public class JavaParameterValue extends ParameterValue {
 
     public void setSelectedJDK(String selectedJDK) {
         this.selectedJDK = selectedJDK;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        return Objects.equals(value, ((JavaParameterValue)obj).getValue());
-    }
-
-    @Override
-    public int hashCode() {
-        return value != null ? value.hashCode() : 37;
     }
 
     @Override
@@ -88,3 +68,5 @@ public class JavaParameterValue extends ParameterValue {
     }
 
 }
+
+

--- a/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
+++ b/src/main/java/com/datalex/jdkparameter/JavaParameterValue.java
@@ -1,13 +1,11 @@
 package com.datalex.jdkparameter;
 
-import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.JDK;
 import hudson.model.ParameterValue;
 import hudson.tasks.BuildWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.util.Locale;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -56,12 +54,6 @@ public class JavaParameterValue extends ParameterValue {
     @Override
     public int hashCode() {
         return value != null ? value.hashCode() : 37;
-    }
-
-    @Override
-    public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
-        env.put(this.name, this.value);
-        env.put(this.name.toUpperCase(Locale.ENGLISH), this.value);
     }
 
     @Override

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/index.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/index.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
             <input type="hidden" name="description" value="${it.description}" />
 
 
-            <select name="value" style="width:100px; margin-left: 15px;">
+            <select name="selectedJDK" style="width:100px; margin-left: 15px;">
                 <j:forEach var="aJDK" items="${it.displayableJDKs}" varStatus="loop">
                     <j:choose>
                         <j:when test="${it.defaultJDK.equals(aJDK)}" >

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
@@ -24,6 +24,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${it.name}" description="${it.description}">
-        <f:textbox name="value" value="${it.value}" readonly="true" />
+        <f:textbox name="selectedJDK" value="${it.selectedJDK}" readonly="true" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
## [JENKINS-70309](https://issues.jenkins.io/browse/JENKINS-70309) Restore the selectedJDK parameter

- [JENKINS-70309] Restore the selectedJDK parameter
- Revert "this change allows this plugin to work with the multijob plugin"
- Revert "Implement equals() and hashCode()"

Returns the plugin to version 1.0 with only the basic modernization changes in order to require a newer Jenkins version.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
