### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,9 @@
 buildPlugin(
   // Container agents start faster and are easier to administer
   useContainerAgent: true,
-  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
-  // Test Java 8 until plugin upgrades to a Jenkins version that does not support Java 8
+  // Test Java 11, 17, and 21
   configurations: [
-    [platform: 'windows', jdk: '17', jenkins: '2.382'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
-    [platform: 'linux',   jdk: '8'],
+    [platform: 'linux',   jdk: '17'],
+    [platform: 'windows', jdk: '11']
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.51</version>
+		<version>4.72</version>
 		<relativePath />
 	</parent>
 
@@ -31,7 +31,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<jenkins.version>2.346.3</jenkins.version>
+		<jenkins.version>2.387.3</jenkins.version>
 	</properties>
 
     <developers>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Necessary in order to test with Java 21.

### Testing done

Confirmed tests pass with Java 21 after this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
