### PR TITLE
[SECURITY-2717] Escape parameter title and description

### DIFF
--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/config.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/config.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
 
     <f:entry title="${%Name}" field="name">
+		<j:set var="escapeEntryTitleAndDescription" value="true"/> <!-- SECURITY-353 defense unless overridden -->
 		<f:textbox name="parameter.name" value="${instance.name}" />
 	</f:entry>
 

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/index.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterDefinition/index.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
          xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 
+    <j:set var="escapeEntryTitleAndDescription" value="true"/> <!-- SECURITY-353 defense unless overridden -->
     <f:entry title="${it.name}" description="${it.description}">
         <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
         <div name="parameter" description="${it.description}">

--- a/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
+++ b/src/main/resources/com/datalex/jdkparameter/JavaParameterValue/value.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <j:set var="escapeEntryTitleAndDescription" value="true"/> <!-- SECURITY-353 defense unless overridden -->
     <f:entry title="${it.name}" description="${it.description}">
         <f:textbox name="selectedJDK" value="${it.selectedJDK}" readonly="true" />
     </f:entry>


### PR DESCRIPTION
## [SECURITY-2717] Escape parameter title and description

[SECURITY-2717](https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2717) describes that the JDK parameter title and description need to be protected.  Changes made in other plugins seem to use this technique to avoid the problem.  Try the same technique here.

### Testing done

Tested interactively and was unable to duplicate the problem before or after the change.  Will need help from the security team to understand how to duplicate the problem and how to confirm that the issue is resolved.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
