### PR TITLE
Fix SCM URL in pom file - correct plugin health score

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -24,14 +23,14 @@
     </licenses>
 
 	<scm>
-	   <connection>scm:git:https://github.com/jenkinsci/JDK_Parameter_Choice.git</connection>
-           <developerConnection>scm:git:git@github.com:jenkinsci/JDK_Parameter_Choice.git</developerConnection>
-           <url>https://github.com/jenkinsci/JDK_Parameter_Choice</url>	
+	   <connection>scm:git:https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin.git</connection>
+           <developerConnection>scm:git:git@github.com:jenkinsci/JDK_Parameter_Plugin-plugin.git</developerConnection>
+           <url>https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin</url>
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
 		<jenkins.baseline>2.479</jenkins.baseline>
-		<jenkins.version>${jenkins.baseline}.1</jenkins.version>
+		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
 	</properties>
 
 	<repositories>
@@ -47,6 +46,4 @@
 			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
-</project>  
-  
-
+</project>


### PR DESCRIPTION
## Fix SCM URL in pom file - correct plugin health score

The repository is https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin but the SCM property was previously pointing to https://github.com/jenkinsci/JDK_Parameter_Choice .  That confuses the plugin health score so that it cannot decide if the repository is archived.

Also updates to require Jenkins 2.479.3 or newer instead of 2.479.1.

### Testing done

Confirmed that automated tests pass with `mvn clean verify`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
