### PR TITLE
Migrate documentation from Wiki to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,11 @@
 
 Adds a build parameter that allows selecting a configured JDK installation for each build.
 
----
-
 ## Description
 
 This plugin adds a build parameter that allows setting which JDK should be used for a job on a per-build basis.
 
 The JDKs available for selection can be configured on the job configuration page when the JDK parameter is enabled.
-
----
-
-## Installation
-
-1. Go to **Manage Jenkins → Manage Plugins**
-2. Search for **JDK Parameter Plugin**
-3. Install the plugin
-4. Restart Jenkins if required
-
----
 
 ## Configuration
 
@@ -34,13 +21,9 @@ To use in a job:
 3. Add parameter → Select **JDK Parameter**
 4. Choose the default JDK and allowed JDK selections
 
----
-
 ## Usage
 
 On the build parameters page, a dropdown list allows selecting which configured JDK should be used for that build.
-
----
 
 ## Pipeline Usage Example
 
@@ -58,25 +41,3 @@ pipeline {
         }
     }
 }
-```
-
----
-
-## Known Issues
-
-During the build phase of a job that has JDK Parameter configured, the job's configured **JDK option** is temporarily replaced with the selected JDK Parameter value and restored after the build.
-
-If multiple builds run concurrently, the original JDK configuration may not always be restored correctly.
-
----
-
-## Compatibility
-
-- Requires Jenkins 2.479.1 or newer
-
----
-
-## Changelog
-
-### Version 1.0
-- Initial release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,82 @@
-JDK Parameter Choice Plugin
-==================================
+# JDK Parameter Plugin
 
-The JDK Parameter Choice Plugin allows you to set a specific JDK to be used with a job at the start of each build.
+Adds a build parameter that allows selecting a configured JDK installation for each build.
+
+---
+
+## Description
+
+This plugin adds a build parameter that allows setting which JDK should be used for a job on a per-build basis.
+
+The JDKs available for selection can be configured on the job configuration page when the JDK parameter is enabled.
+
+---
+
+## Installation
+
+1. Go to **Manage Jenkins → Manage Plugins**
+2. Search for **JDK Parameter Plugin**
+3. Install the plugin
+4. Restart Jenkins if required
+
+---
+
+## Configuration
+
+1. Go to **Manage Jenkins → Global Tool Configuration**
+2. Configure one or more JDK installations
+3. Save the configuration
+
+To use in a job:
+
+1. Open the job configuration page
+2. Enable **This build is parameterized**
+3. Add parameter → Select **JDK Parameter**
+4. Choose the default JDK and allowed JDK selections
+
+---
+
+## Usage
+
+On the build parameters page, a dropdown list allows selecting which configured JDK should be used for that build.
+
+---
+
+## Pipeline Usage Example
+
+```groovy
+pipeline {
+    agent any
+    parameters {
+        jdk(name: 'JDK17')
+    }
+    stages {
+        stage('Check Java Version') {
+            steps {
+                sh 'java -version'
+            }
+        }
+    }
+}
+```
+
+---
+
+## Known Issues
+
+During the build phase of a job that has JDK Parameter configured, the job's configured **JDK option** is temporarily replaced with the selected JDK Parameter value and restored after the build.
+
+If multiple builds run concurrently, the original JDK configuration may not always be restored correctly.
+
+---
+
+## Compatibility
+
+- Requires Jenkins 2.479.1 or newer
+
+---
+
+## Changelog
+
+### Version 1.0
+- Initial release

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<version>1.4-SNAPSHOT</version>
     <name>JDK Parameter Plugin</name>
 	<packaging>hpi</packaging>
-	<url>https://wiki.jenkins-ci.org/display/JENKINS/JDK+Parameter+Plugin</url>
+	<url>https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
## Description

This PR migrates the plugin documentation from the Jenkins Wiki export to the GitHub README.

The existing README was very minimal and had not been updated in many years.  
I have restructured the documentation in Markdown format and moved the relevant content from the Wiki export, including:

- Description
- Installation steps
- Configuration details
- Usage section
- Known issues
- Changelog

I also added a simple Pipeline usage example to make the documentation clearer for users.

This follows the documentation migration effort described in JENKINS-59467.

---

## Testing done

This change only updates documentation.

I verified that the Markdown renders correctly in the GitHub preview.  
No source code or runtime behavior was modified.